### PR TITLE
Add Flintegrate Command Alias and Correct README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ installation on Enterprise Linux 7 series distributions, e.g. CentOS
    `openflight-dev.repo`:
 
    ```
-   cd /etc/yum/repos.d
+   cd /etc/yum.repos.d
    # For production releases
    wget https://openflighthpc.s3-eu-west-1.amazonaws.com/repos/openflight/openflight.repo
    # For development releases

--- a/etc/profile.d/05-flight.csh
+++ b/etc/profile.d/05-flight.csh
@@ -32,6 +32,7 @@ alias flight $prefix'$flight_ROOT/bin/flight \!*; '$postfix
 alias fl $prefix'$flight_ROOT/bin/flight \!*; '$postfix
 alias flexec $prefix'$flight_ROOT/bin/flexec \!*; '$postfix
 alias flactivate $prefix'$flight_ROOT/bin/flactivate \!*; '$postfix
+alias flintegrate $prefix'$flight_ROOT/bin/flintegrate \!*; '$postfix
 
 unset prefix
 unset postfix

--- a/etc/profile.d/05-flight.sh
+++ b/etc/profile.d/05-flight.sh
@@ -29,4 +29,8 @@ flexec() {
   fi
 }
 
-export -f flight fl flexec flactivate
+flintegrate() {
+  ${flight_ROOT}/bin/flintegrate "$@"
+}
+
+export -f flight fl flexec flactivate flintegrate


### PR DESCRIPTION
An alias for `flintegrate` was missing from the profile scripts.

The README had the incorrect yum repo path.