### PR TITLE
Fix assumption that PATH has been exported

### DIFF
--- a/bin/flight
+++ b/bin/flight
@@ -174,6 +174,10 @@ setup
 
 if ! type flexec &>/dev/null; then
   PATH=${flight_ROOT}/bin:$PATH
+  # It's possible that PATH hasn't been exported.  This could occur if a
+  # service runs flight with a (foolishly?) minimal environment.  It's easier
+  # to export PATH than to consider exactly how minimal is foolishly minimal.
+  export PATH
 fi
 
 main "$@"


### PR DESCRIPTION
When `/opt/flight/bin/flight` is ran, it's possible that `PATH` hasn't been exported.  This could occur if a service runs flight with a
(foolishly?) minimal environment.  It's easier to export `PATH` than to consider exactly how minimal is foolishly minimal.