### PR TITLE
Fix tcsh flight alias to run code in the current shell

### DIFF
--- a/etc/profile.d/05-flight.csh
+++ b/etc/profile.d/05-flight.csh
@@ -28,7 +28,7 @@ if ($?noglob) then
 endif
 set postfix = "set _exit="'$status'"; $postfix; test 0 = "'$_exit;'
 
-alias flight $prefix'$flight_ROOT/bin/flight \!*; '$postfix
+alias flight $prefix'source $flight_ROOT/libexec/runway/flight.csh; '$postfix
 alias fl $prefix'$flight_ROOT/bin/flight \!*; '$postfix
 alias flexec $prefix'$flight_ROOT/bin/flexec \!*; '$postfix
 alias flactivate $prefix'$flight_ROOT/bin/flactivate \!*; '$postfix

--- a/libexec/runway/flight.csh
+++ b/libexec/runway/flight.csh
@@ -1,0 +1,20 @@
+################################################################################
+##
+## Flight Runway
+## Copyright (c) 2019-present Alces Flight Ltd
+##
+################################################################################
+
+if ("$1" != "") then
+  set cmd=`$flight_ROOT/bin/flight --resolve stop`
+  alias | grep ^flight_$cmd >/dev/null
+  if ($? == 0) then
+    eval "flight_$cmd ${argv[2-]}"
+    eval "unset cmd; bash -c 'exit $?'"
+  else
+    unset cmd
+    flexec flight $argv
+  endif
+else
+  flexec flight $argv
+endif


### PR DESCRIPTION
The flight-stop command needs to run in the current shell
in order to function. This was implemented in bash but not
tcsh